### PR TITLE
Fix warnings for 1.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /deps
 erl_crash.dump
 *.ez
+test/data_paths

--- a/lib/nsq/conn_info.ex
+++ b/lib/nsq/conn_info.ex
@@ -70,9 +70,9 @@ defmodule NSQ.ConnInfo do
     Agent.get agent_pid, fn(data) ->
       conn_map = data[conn_id] || %{}
       if is_list(keys) do
-        Enum.map keys, &Dict.get(conn_map, &1)
+        Enum.map keys, &Map.get(conn_map, &1)
       else
-        Dict.get(conn_map, keys)
+        Map.get(conn_map, keys)
       end
     end
   end
@@ -96,7 +96,7 @@ defmodule NSQ.ConnInfo do
   """
   def update(agent_pid, conn_id, func) when is_pid(agent_pid) and is_function(func) do
     Agent.update agent_pid, fn(data) ->
-      Dict.put(data, conn_id, func.(data[conn_id] || %{}))
+      Map.put(data, conn_id, func.(data[conn_id] || %{}))
     end
   end
 
@@ -107,8 +107,8 @@ defmodule NSQ.ConnInfo do
   """
   def update(agent_pid, conn_id, map) when is_pid(agent_pid) and is_map(map) do
     Agent.update agent_pid, fn(data) ->
-      new_conn_data = Dict.merge(data[conn_id] || %{}, map)
-      Dict.put(data, conn_id, new_conn_data)
+      new_conn_data = Map.merge(data[conn_id] || %{}, map)
+      Map.put(data, conn_id, new_conn_data)
     end
   end
 
@@ -130,7 +130,7 @@ defmodule NSQ.ConnInfo do
   connection is terminated.
   """
   def delete(agent_pid, conn_id) when is_pid(agent_pid) do
-    Agent.update(agent_pid, fn(data) -> Dict.delete(data, conn_id) end)
+    Agent.update(agent_pid, fn(data) -> Map.delete(data, conn_id) end)
   end
 
 

--- a/lib/nsq/conn_info.ex
+++ b/lib/nsq/conn_info.ex
@@ -147,7 +147,7 @@ defmodule NSQ.ConnInfo do
       rdy_count: 0,
       last_rdy: 0,
       messages_in_flight: 0,
-      last_msg_timestamp: now,
+      last_msg_timestamp: now(),
       retry_rdy_pid: nil,
       finished_count: 0,
       requeued_count: 0,

--- a/lib/nsq/connection.ex
+++ b/lib/nsq/connection.ex
@@ -199,7 +199,7 @@ defmodule NSQ.Connection do
         Logger.error "#{inspect conn}: Timed out waiting for messages to finish. Exiting anyway."
     end
 
-    Process.exit(self, :normal)
+    Process.exit(self(), :normal)
   end
 
   @doc """

--- a/lib/nsq/connection/buffer.ex
+++ b/lib/nsq/connection/buffer.ex
@@ -40,7 +40,7 @@ defmodule NSQ.Connection.Buffer do
           state = %{state | compression: :deflate}
           case state.type do
             :reader ->
-              %{state | zin: open_zin!} |> convert_plaintext_buffer(:deflate)
+              %{state | zin: open_zin!()} |> convert_plaintext_buffer(:deflate)
             :writer ->
               %{state | zout: open_zout!(level)}
           end

--- a/lib/nsq/connection/message_handling.ex
+++ b/lib/nsq/connection/message_handling.ex
@@ -106,7 +106,7 @@ defmodule NSQ.Connection.MessageHandling do
     message = NSQ.Message.from_data(data)
     state = received_message(state)
     message = %NSQ.Message{message |
-      connection: self,
+      connection: self(),
       consumer: state.parent,
       reader: state.reader,
       writer: state.writer,
@@ -127,7 +127,7 @@ defmodule NSQ.Connection.MessageHandling do
       %{info |
         rdy_count: info.rdy_count - 1,
         messages_in_flight: info.messages_in_flight + 1,
-        last_msg_timestamp: now
+        last_msg_timestamp: now()
       }
     end
     state

--- a/lib/nsq/consumer.ex
+++ b/lib/nsq/consumer.ex
@@ -176,7 +176,7 @@ defmodule NSQ.Consumer do
 
     cons_state = %{cons_state | max_in_flight: cons_state.config.max_in_flight}
 
-    {:ok, _cons_state} = Connections.discover_nsqds_and_connect(self, cons_state)
+    {:ok, _cons_state} = Connections.discover_nsqds_and_connect(self(), cons_state)
   end
 
 
@@ -187,7 +187,7 @@ defmodule NSQ.Consumer do
   @spec handle_call(:redistribute_rdy, {reference, pid}, cons_state) ::
     {:reply, :ok, cons_state}
   def handle_call(:redistribute_rdy, _from, cons_state) do
-    {:reply, :ok, RDY.redistribute!(self, cons_state)}
+    {:reply, :ok, RDY.redistribute!(self(), cons_state)}
   end
 
 
@@ -218,14 +218,14 @@ defmodule NSQ.Consumer do
   @spec handle_call({:start_stop_continue_backoff, atom}, {reference, pid}, cons_state) ::
     {:reply, :ok, cons_state}
   def handle_call({:start_stop_continue_backoff, backoff_flag}, _from, cons_state) do
-    {:reply, :ok, Backoff.start_stop_continue!(self, backoff_flag, cons_state)}
+    {:reply, :ok, Backoff.start_stop_continue!(self(), backoff_flag, cons_state)}
   end
 
 
   @spec handle_call({:update_rdy, connection, integer}, {reference, pid}, cons_state) ::
     {:reply, :ok, cons_state}
   def handle_call({:update_rdy, conn, count}, _from, cons_state) do
-    {:reply, :ok, RDY.update!(self, conn, count, cons_state)}
+    {:reply, :ok, RDY.update!(self(), conn, count, cons_state)}
   end
 
 
@@ -290,7 +290,7 @@ defmodule NSQ.Consumer do
   """
   @spec handle_cast(:resume, cons_state) :: {:noreply, cons_state}
   def handle_cast(:resume, state) do
-    {:noreply, Backoff.resume!(self, state)}
+    {:noreply, Backoff.resume!(self(), state)}
   end
 
 
@@ -301,8 +301,8 @@ defmodule NSQ.Consumer do
   @spec handle_cast({:maybe_update_rdy, host_with_port}, cons_state) ::
     {:noreply, cons_state}
   def handle_cast({:maybe_update_rdy, {_host, _port} = nsqd}, cons_state) do
-    conn = conn_from_nsqd(self, nsqd, cons_state)
-    {:noreply, RDY.maybe_update!(self, conn, cons_state)}
+    conn = conn_from_nsqd(self(), nsqd, cons_state)
+    {:noreply, RDY.maybe_update!(self(), conn, cons_state)}
   end
 
 

--- a/lib/nsq/consumer/connections.ex
+++ b/lib/nsq/consumer/connections.ex
@@ -196,7 +196,7 @@ defmodule NSQ.Consumer.Connections do
   Not for external use.
   """
   @spec cleanup_connection(pid, C.host_with_port, C.state) :: {:ok, C.state}
-  def cleanup_connection(cons, conn_id, cons_state) do
+  def cleanup_connection(_cons, conn_id, cons_state) do
     # If a connection is terminated normally or non-normally, it will still be
     # listed in the supervision tree. Let's remove it when we clean up.
     Supervisor.delete_child(cons_state.conn_sup_pid, conn_id)

--- a/lib/nsq/consumer/connections.ex
+++ b/lib/nsq/consumer/connections.ex
@@ -22,7 +22,7 @@ defmodule NSQ.Consumer.Connections do
       lookupd_poll_interval: poll_interval,
       lookupd_poll_jitter: poll_jitter
     } = cons_state.config
-    delay = poll_interval + round(poll_interval * poll_jitter * :random.uniform)
+    delay = poll_interval + round(poll_interval * poll_jitter * :rand.uniform)
     :timer.sleep(delay)
 
     GenServer.call(cons, :discover_nsqds)

--- a/lib/nsq/consumer/connections.ex
+++ b/lib/nsq/consumer/connections.ex
@@ -31,7 +31,7 @@ defmodule NSQ.Consumer.Connections do
 
 
   def close(cons_state) do
-    Logger.info "Closing connections for consumer #{inspect self}"
+    Logger.info "Closing connections for consumer #{inspect self()}"
     connections = get(cons_state)
     Enum.map connections, fn({_, conn_pid}) ->
       Task.start_link(NSQ.Connection, :close, [conn_pid])
@@ -48,7 +48,7 @@ defmodule NSQ.Consumer.Connections do
   def refresh(cons_state) do
     {:ok, cons_state} = delete_dead(cons_state)
     {:ok, cons_state} = reconnect_failed(cons_state)
-    {:ok, cons_state} = discover_nsqds_and_connect(self, cons_state)
+    {:ok, cons_state} = discover_nsqds_and_connect(self(), cons_state)
     {:ok, cons_state}
   end
 
@@ -67,12 +67,12 @@ defmodule NSQ.Consumer.Connections do
   def discover_nsqds_and_connect(cons, cons_state) do
     nsqds = cond do
       length(cons_state.config.nsqlookupds) > 0 ->
-        Logger.debug "(#{inspect self}) Discovering nsqds via nsqlookupds #{inspect cons_state.config.nsqlookupds}"
+        Logger.debug "(#{inspect self()}) Discovering nsqds via nsqlookupds #{inspect cons_state.config.nsqlookupds}"
         cons_state.config.nsqlookupds
         |> NSQ.Lookupd.nsqds_with_topic(cons_state.topic)
 
       length(cons_state.config.nsqds) > 0 ->
-        Logger.debug "(#{inspect self}) Using configured nsqds #{inspect cons_state.config.nsqds}"
+        Logger.debug "(#{inspect self()}) Using configured nsqds #{inspect cons_state.config.nsqds}"
         cons_state.config.nsqds
 
       true ->
@@ -284,7 +284,7 @@ defmodule NSQ.Consumer.Connections do
     if is_integer(active) do
       active
     else
-      Logger.warn "(#{inspect self}) non-integer #{inspect active} returned counting connections, returning 0 instead"
+      Logger.warn "(#{inspect self()}) non-integer #{inspect active} returned counting connections, returning 0 instead"
       0
     end
   end
@@ -322,7 +322,7 @@ defmodule NSQ.Consumer.Connections do
       [last_msg_t, rdy_count] = ConnInfo.fetch(
         cons_state, conn_id, [:last_msg_timestamp, :rdy_count]
       )
-      sec_since_last_msg = now - last_msg_t
+      sec_since_last_msg = now() - last_msg_t
       ms_since_last_msg = sec_since_last_msg * 1000
 
       Logger.debug(

--- a/lib/nsq/message.ex
+++ b/lib/nsq/message.ex
@@ -37,7 +37,7 @@ defmodule NSQ.Message do
 
   def init(message) do
     # Process the message asynchronously after init.
-    GenServer.cast(self, :process)
+    GenServer.cast(self(), :process)
     {:ok, message}
   end
 
@@ -70,7 +70,7 @@ defmodule NSQ.Message do
   def process(message) do
     # Kick off processing in a separate process, so we can kill it if it takes
     # too long.
-    message = %{message | parent: self}
+    message = %{message | parent: self()}
     {:ok, pid} = Task.start_link fn ->
       process_without_timeout(message)
     end
@@ -85,7 +85,7 @@ defmodule NSQ.Message do
     send(message.connection, result)
 
     # Nothing more for this process to do.
-    Process.exit(self, :normal)
+    Process.exit(self(), :normal)
   end
 
 

--- a/lib/nsq/message.ex
+++ b/lib/nsq/message.ex
@@ -253,7 +253,7 @@ defmodule NSQ.Message do
 
   defp calculate_delay(attempts, max_requeue_delay) do
     exponential_backoff = :math.pow(2, attempts) * 1000
-    jitter = round(0.3 * :random.uniform * exponential_backoff)
+    jitter = round(0.3 * :rand.uniform * exponential_backoff)
     min(
       exponential_backoff + jitter,
       max_requeue_delay

--- a/lib/nsq/producer.ex
+++ b/lib/nsq/producer.ex
@@ -102,7 +102,7 @@ defmodule NSQ.Producer do
       end
     pro_state = %{pro_state | event_manager_pid: manager}
 
-    {:ok, _pro_state} = connect_to_nsqds(pro_state.config.nsqds, self, pro_state)
+    {:ok, _pro_state} = connect_to_nsqds(pro_state.config.nsqds, self(), pro_state)
   end
 
 

--- a/test/consumer_test.exs
+++ b/test/consumer_test.exs
@@ -20,7 +20,6 @@ defmodule NSQ.ConsumerTest do
 
   @test_topic "__nsq_consumer_test_topic__"
   @test_channel1 "__nsq_consumer_test_channel1__"
-  @test_channel2 "__nsq_consumer_test_channel2__"
 
   setup do
     Logger.configure(level: :warn)
@@ -706,7 +705,7 @@ defmodule NSQ.ConsumerTest do
     {:ok, cons_sup_pid} = NSQ.Consumer.Supervisor.start_link(@test_topic, @test_channel1, %NSQ.Config{
       msg_timeout: 1000,
       nsqds: [{"127.0.0.1", 6750}],
-      message_handler: fn(body, msg) -> :ok end
+      message_handler: fn(_body, _msg) -> :ok end
     })
 
     consumer = NSQ.Consumer.get(cons_sup_pid)

--- a/test/consumer_test.exs
+++ b/test/consumer_test.exs
@@ -32,7 +32,7 @@ defmodule NSQ.ConsumerTest do
   end
 
   test "msg_timeout" do
-    test_pid = self
+    test_pid = self()
     {:ok, consumer} = NSQ.Consumer.Supervisor.start_link(@test_topic, @test_channel1, %NSQ.Config{
       nsqds: [{"127.0.0.1", 6750}],
       msg_timeout: 1000,
@@ -48,7 +48,7 @@ defmodule NSQ.ConsumerTest do
     })
 
     NSQ.Consumer.event_manager(consumer)
-      |> GenEvent.add_handler(NSQ.ConsumerTest.EventForwarder, self)
+      |> GenEvent.add_handler(NSQ.ConsumerTest.EventForwarder, self())
 
     HTTP.post("http://127.0.0.1:6751/put?topic=#{@test_topic}", [body: "hello"])
     assert_receive {:message_finished, _}, 2000
@@ -58,7 +58,7 @@ defmodule NSQ.ConsumerTest do
   end
 
   test "NSQ.Message.touch extends timeout" do
-    test_pid = self
+    test_pid = self()
     {:ok, consumer} = NSQ.Consumer.Supervisor.start_link(@test_topic, @test_channel1, %NSQ.Config{
       nsqds: [{"127.0.0.1", 6750}],
       msg_timeout: 1000,
@@ -74,7 +74,7 @@ defmodule NSQ.ConsumerTest do
     })
 
     NSQ.Consumer.event_manager(consumer)
-      |> GenEvent.add_handler(NSQ.ConsumerTest.EventForwarder, self)
+      |> GenEvent.add_handler(NSQ.ConsumerTest.EventForwarder, self())
 
     HTTP.post("http://127.0.0.1:6751/put?topic=#{@test_topic}", [body: "hello"])
 
@@ -86,7 +86,7 @@ defmodule NSQ.ConsumerTest do
   end
 
   test "we don't go over max_in_flight, and keep processing after saturation" do
-    test_pid = self
+    test_pid = self()
     {:ok, consumer} = NSQ.Consumer.Supervisor.start_link(@test_topic, @test_channel1, %NSQ.Config{
       nsqds: [{"127.0.0.1", 6750}, {"127.0.0.1", 6760}],
       max_in_flight: 4,
@@ -120,7 +120,7 @@ defmodule NSQ.ConsumerTest do
   end
 
   test "closing the connection waits for outstanding messages and cleanly exits" do
-    test_pid = self
+    test_pid = self()
     {:ok, consumer} = NSQ.Consumer.Supervisor.start_link(@test_topic, @test_channel1, %NSQ.Config{
       nsqds: [{"127.0.0.1", 6750}],
       message_handler: fn(body, _msg) ->
@@ -148,7 +148,7 @@ defmodule NSQ.ConsumerTest do
   end
 
   test "notifies the event manager of relevant events" do
-    test_pid = self
+    test_pid = self()
     {:ok, consumer} = NSQ.Consumer.Supervisor.start_link(@test_topic, @test_channel1, %NSQ.Config{
       nsqds: [{"127.0.0.1", 6750}],
       message_handler: fn(_body, _msg) ->
@@ -158,7 +158,7 @@ defmodule NSQ.ConsumerTest do
     })
 
     NSQ.Consumer.event_manager(consumer)
-      |> GenEvent.add_handler(NSQ.ConsumerTest.EventForwarder, self)
+      |> GenEvent.add_handler(NSQ.ConsumerTest.EventForwarder, self())
 
     HTTP.post("http://127.0.0.1:6751/put?topic=#{@test_topic}", [body: "HTTP message"])
     assert_receive(:handled, 2000)
@@ -184,7 +184,7 @@ defmodule NSQ.ConsumerTest do
     })
 
     NSQ.Consumer.event_manager(consumer)
-      |> GenEvent.add_handler(NSQ.ConsumerTest.EventForwarder, self)
+      |> GenEvent.add_handler(NSQ.ConsumerTest.EventForwarder, self())
 
     [info] = NSQ.Consumer.conn_info(consumer) |> Map.values
     previous_timestamp = info.last_msg_timestamp
@@ -220,7 +220,7 @@ defmodule NSQ.ConsumerTest do
   end
 
   test "a connection is terminated, cleaned up, and restarted when the tcp connection closes" do
-    test_pid = self
+    test_pid = self()
     {:ok, cons_sup_pid} = NSQ.Consumer.Supervisor.start_link(@test_topic, @test_channel1, %NSQ.Config{
       lookupd_poll_interval: 500,
       nsqds: [{"127.0.0.1", 6750}],
@@ -261,7 +261,7 @@ defmodule NSQ.ConsumerTest do
   end
 
   test "establishes a connection to NSQ and processes messages" do
-    test_pid = self
+    test_pid = self()
     NSQ.Consumer.Supervisor.start_link(@test_topic, @test_channel1, %NSQ.Config{
       nsqds: [{"127.0.0.1", 6750}],
       message_handler: fn(body, msg) ->
@@ -280,7 +280,7 @@ defmodule NSQ.ConsumerTest do
   end
 
   test "discovery via nsqlookupd" do
-    test_pid = self
+    test_pid = self()
     {:ok, _} = NSQ.Consumer.Supervisor.start_link(@test_topic, @test_channel1, %NSQ.Config{
       lookupd_poll_interval: 500,
       nsqlookupds: ["127.0.0.1:6771", "127.0.0.1:6781"],
@@ -300,7 +300,7 @@ defmodule NSQ.ConsumerTest do
   end
 
   test "#start_link lives when given a bad address and not able to reconnect" do
-    test_pid = self
+    test_pid = self()
     Process.flag(:trap_exit, true)
     {:ok, consumer} = NSQ.Consumer.Supervisor.start_link(@test_topic, @test_channel1, %NSQ.Config{
       nsqds: [{"127.0.0.1", 7777}],
@@ -318,7 +318,7 @@ defmodule NSQ.ConsumerTest do
 
 
   test "#start_link lives when given a bad address but able to reconnect" do
-    test_pid = self
+    test_pid = self()
     {:ok, consumer} = NSQ.Consumer.Supervisor.start_link(@test_topic, @test_channel1, %NSQ.Config{
       nsqds: [{"127.0.0.1", 7777}],
       max_reconnect_attempts: 2,
@@ -340,7 +340,7 @@ defmodule NSQ.ConsumerTest do
 
 
   test "receives messages from mpub" do
-    test_pid = self
+    test_pid = self()
     NSQ.Consumer.Supervisor.start_link(@test_topic, @test_channel1, %NSQ.Config{
       nsqds: [{"127.0.0.1", 6750}],
       message_handler: fn(body, _msg) ->
@@ -364,7 +364,7 @@ defmodule NSQ.ConsumerTest do
   end
 
   test "processes many messages concurrently" do
-    test_pid = self
+    test_pid = self()
     NSQ.Consumer.Supervisor.start_link(@test_topic, @test_channel1, %NSQ.Config{
       nsqds: [{"127.0.0.1", 6750}],
       message_handler: fn(_body, _msg) ->
@@ -409,7 +409,7 @@ defmodule NSQ.ConsumerTest do
     })
 
     NSQ.Consumer.event_manager(sup_pid)
-      |> GenEvent.add_handler(NSQ.ConsumerTest.EventForwarder, self)
+      |> GenEvent.add_handler(NSQ.ConsumerTest.EventForwarder, self())
 
     consumer = Cons.get(sup_pid)
     cons_state = Cons.get_state(consumer)
@@ -489,7 +489,7 @@ defmodule NSQ.ConsumerTest do
     # to send RDY 1. That will trigger a retry, after which we can change the
     # max_in_flight so it succeeds next time.
 
-    test_pid = self
+    test_pid = self()
     {:ok, cons_sup_pid} = NSQ.Consumer.Supervisor.start_link(@test_topic, @test_channel1, %NSQ.Config{
       nsqds: [{"127.0.0.1", 6750}],
       max_in_flight: 0,
@@ -519,7 +519,7 @@ defmodule NSQ.ConsumerTest do
   end
 
   test "rdy redistribution when number of connections > max in flight" do
-    test_pid = self
+    test_pid = self()
     {:ok, cons_sup_pid} = NSQ.Consumer.Supervisor.start_link(@test_topic, @test_channel1, %NSQ.Config{
       nsqds: [{"127.0.0.1", 6750}, {"127.0.0.1", 6760}],
       rdy_redistribute_interval: 100,
@@ -555,7 +555,7 @@ defmodule NSQ.ConsumerTest do
   end
 
   test "works with tls" do
-    test_pid = self
+    test_pid = self()
     NSQ.Consumer.Supervisor.start_link(@test_topic, @test_channel1, %NSQ.Config{
       nsqds: [{"127.0.0.1", 6750}],
       tls_v1: true,
@@ -581,7 +581,7 @@ defmodule NSQ.ConsumerTest do
 
   unless System.get_env("CI") == "true" do
     test "fails when tls_insecure_skip_verify is false" do
-      test_pid = self
+      test_pid = self()
       NSQ.Consumer.Supervisor.start_link(@test_topic, @test_channel1, %NSQ.Config{
         nsqds: [{"127.0.0.1", 6750}],
         tls_v1: true,
@@ -613,7 +613,7 @@ defmodule NSQ.ConsumerTest do
     })
 
     NSQ.Consumer.event_manager(consumer)
-      |> GenEvent.add_handler(NSQ.ConsumerTest.EventForwarder, self)
+      |> GenEvent.add_handler(NSQ.ConsumerTest.EventForwarder, self())
 
     # Nothing is in flight, not starved
     assert NSQ.Consumer.starved?(consumer) == false
@@ -636,7 +636,7 @@ defmodule NSQ.ConsumerTest do
   end
 
   test "auth" do
-    test_pid = self
+    test_pid = self()
     NSQ.Consumer.Supervisor.start_link(@test_topic, @test_channel1, %NSQ.Config{
       nsqds: [{"127.0.0.1", 6765}],
       auth_secret: "abc",
@@ -656,7 +656,7 @@ defmodule NSQ.ConsumerTest do
   end
 
   test "deflate" do
-    test_pid = self
+    test_pid = self()
     NSQ.Consumer.Supervisor.start_link(@test_topic, @test_channel1, %NSQ.Config{
       nsqds: [{"127.0.0.1", 6750}],
       deflate: true,
@@ -676,7 +676,7 @@ defmodule NSQ.ConsumerTest do
   end
 
   test "deflate + ssl + auth" do
-    test_pid = self
+    test_pid = self()
     NSQ.Consumer.Supervisor.start_link(@test_topic, @test_channel1, %NSQ.Config{
       nsqds: [{"127.0.0.1", 6765}],
       deflate: true,

--- a/test/message_test.exs
+++ b/test/message_test.exs
@@ -7,7 +7,7 @@ defmodule NSQ.MessageTest do
   end
 
   def build_raw_nsq_data(attrs \\ %{}) do
-    timestamp = attrs[:timestamp] || now
+    timestamp = attrs[:timestamp] || now()
     attempts = attrs[:attempts] || 0
     msg_id = attrs[:id] || String.ljust(SecureRandom.hex(8), 16, ?0)
     data = attrs[:body] || "test data"

--- a/test/producer_test.exs
+++ b/test/producer_test.exs
@@ -40,7 +40,7 @@ defmodule NSQ.ProducerTest do
       @test_topic, %NSQ.Config{nsqds: @configured_nsqds}
     )
 
-    test_pid = self
+    test_pid = self()
     NSQ.Consumer.Supervisor.start_link(@test_topic, @test_channel1, %NSQ.Config{
       nsqds: @configured_nsqds,
       message_handler: fn(body, msg) ->
@@ -60,7 +60,7 @@ defmodule NSQ.ProducerTest do
       @test_topic, %NSQ.Config{nsqds: @configured_nsqds}
     )
 
-    test_pid = self
+    test_pid = self()
     {:ok, bodies} = Agent.start_link(fn -> [] end)
     NSQ.Consumer.Supervisor.start_link(@test_topic, @test_channel1, %NSQ.Config{
       nsqds: @configured_nsqds,


### PR DESCRIPTION
I went ahead and fixed all the straightforward warnings while I was at it and added the newly created `test/data_paths` to .gitignore.  There's still a slew of unsafe variable warnings:
 ```
warning: the variable "conn_state" is unsafe as it has been set inside a case/cond/receive/if/&&/||.
```
but since they require actually restructuring things I refrained from touching them for now.  Happy to take a stab at that, too, if it's welcome.