### PR TITLE
Fix socket options for newest elixir-socket package

### DIFF
--- a/lib/nsq/connection/initializer.ex
+++ b/lib/nsq/connection/initializer.ex
@@ -6,7 +6,7 @@ defmodule NSQ.Connection.Initializer do
   import NSQ.Protocol
   require Logger
 
-  @socket_opts [as: :binary, active: false, deliver: :term, packet: :raw]
+  @socket_opts [as: :binary, mode: :passive, packet: :raw]
 
   @project ElixirNsq.Mixfile.project
   @user_agent "#{@project[:app]}/#{@project[:version]}"
@@ -17,7 +17,7 @@ defmodule NSQ.Connection.Initializer do
   def connect(%{nsqd: {host, port}} = state) do
     if should_connect?(state) do
       socket_opts = @socket_opts |> Keyword.merge(
-        send_timeout: state.config.write_timeout,
+        send: [{:timeout, state.config.write_timeout}],
         timeout: state.config.dial_timeout,
       )
 

--- a/mix.exs
+++ b/mix.exs
@@ -34,7 +34,7 @@ defmodule ElixirNsq.Mixfile do
       {:ibrowse, "~> 4.2"},
       {:httpotion, "~> 2.1.0"},
       {:uuid, "~> 1.1.2"},
-      {:socket, ">= 0.3.1 and <= 0.3.5"},
+      {:socket, "~> 0.3.1"},
 
       # testing
       {:secure_random, "~> 0.2", only: :test},

--- a/mix.lock
+++ b/mix.lock
@@ -7,5 +7,5 @@
   "poison": {:hex, :poison, "1.5.0", "f2f4f460623a6f154683abae34352525e1d918380267cdbd949a07ba57503248", [:mix], []},
   "ranch": {:hex, :ranch, "1.2.0", "b286a948a0706a700a9f577e5cecbb2dc66097ea79f3ddb20ba5536069bdb7aa", [:make], []},
   "secure_random": {:hex, :secure_random, "0.2.0", "d5458ab5613410439c21a2fdbc52e98e6c96338f3ea25d08220c30cfc55f1238", [:mix], []},
-  "socket": {:hex, :socket, "0.3.1", "c17c6da3f85ae07b730fcfa3b9b44051e1f7cbd5c202c46ea926493004d4cc18", [:mix], []},
+  "socket": {:hex, :socket, "0.3.7", "68c029a8449fc6efc5f4c3bdf6d8b19ca94d3304e419f364c5cfc8b716f7c219", [:mix], []},
   "uuid": {:hex, :uuid, "1.1.2", "add3d0a6324ac2e3974855822ddf1cd4e270d8c136a75bcb71332bd4956b0563", [:mix], []}}


### PR DESCRIPTION
Here's a fix for issue https://github.com/wistia/elixir_nsq/issues/6.  The problem was that the option handling was sneakily changed in this innocuous ["fix warnings"](https://github.com/meh/elixir-socket/commit/930647db281eec4d070c7ef831484cdc0b89dd56) commit to elixir-socket.  Now, instead of silently ignoring any unknown options to `Socket.connect` it barfs when the pattern match fails.  The handling of  `send_timeout` was also changed so that now an embedded keyword list is needed.  The other thing I noticed is that the `deliver: : term` option was never passed through to `:inet.setopts/2` even in the earlier versions of elixir-socket so I removed it.

Just as a side note: I didn't have a lot of confidence in this library after taking a closer look at the code and the complete absence of tests wasn't very convincing either.  It may be worth considering whether or not it's worth cutting the dependency completely and just using gen_tcp directly.  Thoughts?
