### PR TITLE
Fix unsafe variable warnings for elixir 1.4

### DIFF
--- a/lib/nsq/connection.ex
+++ b/lib/nsq/connection.ex
@@ -143,10 +143,11 @@ defmodule NSQ.Connection do
 
 
   @spec handle_cast(:reconnect, state) :: {:noreply, state}
+  def handle_cast(:reconnect, %{connect_attempts: connect_attempts} = conn_state) when connect_attempts > 0 do
+    {_, conn_state} = Initializer.connect(conn_state)
+    {:noreply, conn_state}
+  end
   def handle_cast(:reconnect, conn_state) do
-    if conn_state.connect_attempts > 0 do
-      {_, conn_state} = Initializer.connect(conn_state)
-    end
     {:noreply, conn_state}
   end
 

--- a/lib/nsq/connection/buffer.ex
+++ b/lib/nsq/connection/buffer.ex
@@ -208,9 +208,12 @@ defmodule NSQ.Connection.Buffer do
           end
       end
 
-    if is_list(decompressed) do
-      decompressed = decompressed |> List.flatten |> Enum.join("")
-    end
+    decompressed =
+      if is_list(decompressed) do
+        decompressed |> List.flatten |> Enum.join("")
+      else
+        decompressed
+      end
 
     combined_buffer = state.buffered_data <> decompressed
 

--- a/lib/nsq/connection/message_handling.ex
+++ b/lib/nsq/connection/message_handling.ex
@@ -29,26 +29,27 @@ defmodule NSQ.Connection.MessageHandling do
     end
   end
 
-
-  def handle_nsq_message(msg, state) do
-    case msg do
-      {:response, "_heartbeat_"} ->
-        respond_to_heartbeat(state)
-
-      {:response, data} ->
-        {:ok, state} = state |> Command.send_response_to_caller(data)
-
-      {:error, data} ->
-        state |> log_error(nil, data)
-
-      {:error, reason, data} ->
-        state |> log_error(reason, data)
-
-      {:message, data} ->
-        {:ok, state} = state |> kick_off_message_processing(data)
-    end
-
+  def handle_nsq_message({:response, "_heartbeat_"}, state) do
+    respond_to_heartbeat(state)
     {:ok, state}
+  end
+
+  def handle_nsq_message({:response, data}, state) do
+    state |> Command.send_response_to_caller(data)
+  end
+
+  def handle_nsq_message({:error, data}, state) do
+    state |> log_error(nil, data)
+    {:ok, state}
+  end
+
+  def handle_nsq_message({:error, reason, data}, state) do
+    state |> log_error(reason, data)
+    {:ok, state}
+  end
+
+  def handle_nsq_message({:message, data}, state) do
+    state |> kick_off_message_processing(data)
   end
 
 

--- a/lib/nsq/consumer/connections.ex
+++ b/lib/nsq/consumer/connections.ex
@@ -134,10 +134,14 @@ defmodule NSQ.Consumer.Connections do
       # `RDY.redistribute` loop will take care of getting this connection some
       # messages later.
       remaining_rdy = cons_state.max_in_flight - total_rdy_count(cons_state)
-      if remaining_rdy > 0 do
-        conn = conn_from_nsqd(cons, nsqd, cons_state)
-        {:ok, cons_state} = RDY.transmit(conn, 1, cons_state)
-      end
+      cons_state =
+        if remaining_rdy > 0 do
+          conn = conn_from_nsqd(cons, nsqd, cons_state)
+          {:ok, cons_state} = RDY.transmit(conn, 1, cons_state)
+          cons_state
+        else
+          cons_state
+        end
 
       {:ok, cons_state}
     catch

--- a/lib/nsq/lookupd.ex
+++ b/lib/nsq/lookupd.ex
@@ -58,9 +58,7 @@ defmodule NSQ.Lookupd do
 
   @spec normalize_200_response([any], binary) :: response
   defp normalize_200_response(headers, body) do
-    if body == nil || body == "" do
-      body = "{}"
-    end
+    body = if body == nil || body == "", do: "{}", else: body
 
     if headers[:"X-Nsq-Content-Type"] == "nsq; version=1.0" do
       Poison.decode!(body)

--- a/lib/nsq/message.ex
+++ b/lib/nsq/message.ex
@@ -110,19 +110,25 @@ defmodule NSQ.Message do
   mode, where it stops receiving messages for a fixed duration.
   """
   def req(message, delay \\ -1, backoff \\ false) do
-    if delay == -1 do
-      delay = calculate_delay(
-        message.attempts, message.config.max_requeue_delay
-      )
-      Logger.debug("(#{inspect message.connection}) requeue msg ID #{message.id}, delay #{delay} (auto-calculated with attempts #{message.attempts}), backoff #{backoff}")
-    else
-      Logger.debug("(#{inspect message.connection}) requeue msg ID #{message.id}, delay #{delay}, backoff #{backoff}")
-    end
+    delay =
+      if delay == -1 do
+        delay = calculate_delay(
+          message.attempts, message.config.max_requeue_delay
+        )
+        Logger.debug("(#{inspect message.connection}) requeue msg ID #{message.id}, delay #{delay} (auto-calculated with attempts #{message.attempts}), backoff #{backoff}")
+        delay
+      else
+        Logger.debug("(#{inspect message.connection}) requeue msg ID #{message.id}, delay #{delay}, backoff #{backoff}")
+        delay
+      end
 
-    if delay > message.config.max_requeue_delay do
-      Logger.warn "Invalid requeue delay #{delay}. Must be between 0 and #{message.config.max_requeue_delay}. Sending with max delay #{message.config.max_requeue_delay} instead."
-      delay = message.config.max_requeue_delay
-    end
+    delay =
+      if delay > message.config.max_requeue_delay do
+        Logger.warn "Invalid requeue delay #{delay}. Must be between 0 and #{message.config.max_requeue_delay}. Sending with max delay #{message.config.max_requeue_delay} instead."
+        message.config.max_requeue_delay
+      else
+        delay
+      end
 
     if backoff do
       GenServer.call(message.consumer, {:start_stop_continue_backoff, :backoff})


### PR DESCRIPTION
This eliminates the rest of the unsafe variable warnings. Some of the changes were very straightforward while for others I thought it was more appropriate to add some extra function clauses to make things more clear/idiomatic.