### PR TITLE
Update Travis config to use elixir 1.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: elixir
 
 elixir:
-  - 1.2.0
+  - 1.2
+  - 1.4
 
 otp_release:
   - 18.0
+  - 19.3
 
 before_install:
   - wget https://github.com/fclairamb/nsq-debian-package/releases/download/0.3.5/nsq_0.3.5_amd64.deb

--- a/mix.exs
+++ b/mix.exs
@@ -40,7 +40,7 @@ defmodule ElixirNsq.Mixfile do
       {:secure_random, "~> 0.2", only: :test},
 
       # Small HTTP server for running tests
-      {:http_server, github: "parroty/http_server", tag: "09ea61f42097483d3e70749be30490004a5df38f", only: :test},
+      {:http_server, github: "parroty/http_server"},
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
 %{"connection": {:hex, :connection, "1.0.1"},
   "cowboy": {:hex, :cowboy, "1.0.4", "a324a8df9f2316c833a470d918aaf73ae894278b8aa6226ce7a9bf699388f878", [:make, :rebar], [{:cowlib, "~> 1.0.0", [hex: :cowlib, optional: false]}, {:ranch, "~> 1.0", [hex: :ranch, optional: false]}]},
   "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], []},
-  "http_server": {:git, "https://github.com/parroty/http_server.git", "09ea61f42097483d3e70749be30490004a5df38f", [tag: "09ea61f42097483d3e70749be30490004a5df38f"]},
+  "http_server": {:git, "https://github.com/parroty/http_server.git", "922d10420836a51289ed04f0bb5022bf695da1ab", []},
   "httpotion": {:hex, :httpotion, "2.1.0", "3fe84fbd13d4560c2514da656d022b1191a079178ee4992d245fc3c33c01ee18", [:mix], []},
   "ibrowse": {:hex, :ibrowse, "4.4.0", "2d923325efe0d2cb09b9c6a047b2835a5eda69d8a47ed6ff8bc03628b764e991", [:rebar3], []},
   "poison": {:hex, :poison, "1.5.0", "f2f4f460623a6f154683abae34352525e1d918380267cdbd949a07ba57503248", [:mix], []},


### PR DESCRIPTION
Hi there,

I updated the travis config to also test with Elixir 1.4 / OTP 19.3
https://travis-ci.org/netantho/elixir_nsq/builds

I had a travis error when trying to use a specific tag for the http_server dependency: https://travis-ci.org/netantho/elixir_nsq/builds/215191629