### PR TITLE
Update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: elixir
 
 elixir:
-  - 1.2
+  - 1.3
   - 1.4
 
 otp_release:

--- a/lib/nsq/lookupd.ex
+++ b/lib/nsq/lookupd.ex
@@ -36,7 +36,7 @@ defmodule NSQ.Lookupd do
   @spec topics_from_lookupd(C.host_with_port, String.t) :: response
   def topics_from_lookupd({host, port}, topic) do
     lookupd_url = "http://#{host}:#{port}/lookup?topic=#{topic}"
-    headers = [{"Accept", "application/vnd.nsq; version=1.0"}]
+    headers = ["Accept": "application/vnd.nsq; version=1.0"]
     try do
       case HTTPotion.get(lookupd_url, headers: headers) do
         %HTTPotion.Response{status_code: 200, body: body, headers: headers} ->

--- a/mix.exs
+++ b/mix.exs
@@ -30,14 +30,13 @@ defmodule ElixirNsq.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [
-      {:poison, "~> 1.5.0"},
-      {:ibrowse, "~> 4.2"},
-      {:httpotion, "~> 2.1.0"},
-      {:uuid, "~> 1.1.2"},
-      {:socket, "~> 0.3.1"},
+      {:poison, "~> 3.1.0"},
+      {:httpotion, "~> 3.0"},
+      {:uuid, "~> 1.1.7"},
+      {:socket, "~> 0.3.11"},
 
       # testing
-      {:secure_random, "~> 0.2", only: :test},
+      {:secure_random, "~> 0.5", only: :test},
 
       # Small HTTP server for running tests
       {:http_server, github: "parroty/http_server"},

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ElixirNsq.Mixfile do
   def project do
     [app: :elixir_nsq,
      version: "1.0.3",
-     elixir: "~> 1.1",
+     elixir: "~> 1.3",
      description: description(),
      package: package(),
      build_embedded: Mix.env == :prod,

--- a/mix.lock
+++ b/mix.lock
@@ -2,10 +2,10 @@
   "cowboy": {:hex, :cowboy, "1.0.4", "a324a8df9f2316c833a470d918aaf73ae894278b8aa6226ce7a9bf699388f878", [:make, :rebar], [{:cowlib, "~> 1.0.0", [hex: :cowlib, optional: false]}, {:ranch, "~> 1.0", [hex: :ranch, optional: false]}]},
   "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], []},
   "http_server": {:git, "https://github.com/parroty/http_server.git", "922d10420836a51289ed04f0bb5022bf695da1ab", []},
-  "httpotion": {:hex, :httpotion, "2.1.0", "3fe84fbd13d4560c2514da656d022b1191a079178ee4992d245fc3c33c01ee18", [:mix], []},
+  "httpotion": {:hex, :httpotion, "3.0.2", "525b9bfeb592c914a61a8ee31fdde3871e1861dfe805f8ee5f711f9f11a93483", [:mix], [{:ibrowse, "~> 4.2", [hex: :ibrowse, optional: false]}]},
   "ibrowse": {:hex, :ibrowse, "4.4.0", "2d923325efe0d2cb09b9c6a047b2835a5eda69d8a47ed6ff8bc03628b764e991", [:rebar3], []},
-  "poison": {:hex, :poison, "1.5.0", "f2f4f460623a6f154683abae34352525e1d918380267cdbd949a07ba57503248", [:mix], []},
+  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], []},
   "ranch": {:hex, :ranch, "1.2.0", "b286a948a0706a700a9f577e5cecbb2dc66097ea79f3ddb20ba5536069bdb7aa", [:make], []},
-  "secure_random": {:hex, :secure_random, "0.2.0", "d5458ab5613410439c21a2fdbc52e98e6c96338f3ea25d08220c30cfc55f1238", [:mix], []},
-  "socket": {:hex, :socket, "0.3.7", "68c029a8449fc6efc5f4c3bdf6d8b19ca94d3304e419f364c5cfc8b716f7c219", [:mix], []},
-  "uuid": {:hex, :uuid, "1.1.2", "add3d0a6324ac2e3974855822ddf1cd4e270d8c136a75bcb71332bd4956b0563", [:mix], []}}
+  "secure_random": {:hex, :secure_random, "0.5.1", "c5532b37c89d175c328f5196a0c2a5680b15ebce3e654da37129a9fe40ebf51b", [:mix], []},
+  "socket": {:hex, :socket, "0.3.11", "46004230045c2207c0b90adb9abe3ba15a83e634b341ac37af39a4adf48ed00b", [:mix], []},
+  "uuid": {:hex, :uuid, "1.1.7", "007afd58273bc0bc7f849c3bdc763e2f8124e83b957e515368c498b641f7ab69", [:mix], []}}


### PR DESCRIPTION
Update dependencies used by elixir_nsq. 

Side effect:
- Elixir 1.2 would not be supported anymore. For information, Elixir 1.3 was released on [Jun 21, 2016](https://github.com/elixir-lang/elixir/releases) [Failed builds](https://travis-ci.org/netantho/elixir_nsq/builds/217524658)

Elixir 1.3 and 1.4 seem to run well [Successful travis build](https://travis-ci.org/netantho/elixir_nsq/builds/217526318)