### PR TITLE
Fix a few Elixir 1.6 compiler warnings

### DIFF
--- a/lib/nsq/connection/initializer.ex
+++ b/lib/nsq/connection/initializer.ex
@@ -18,7 +18,7 @@ defmodule NSQ.Connection.Initializer do
     if should_connect?(state) do
       socket_opts = @socket_opts |> Keyword.merge(
         send: [{:timeout, state.config.write_timeout}],
-        timeout: state.config.dial_timeout,
+        timeout: state.config.dial_timeout
       )
 
       case Socket.TCP.connect(host, port, socket_opts) do

--- a/lib/nsq/message.ex
+++ b/lib/nsq/message.ex
@@ -191,6 +191,11 @@ defmodule NSQ.Message do
       result = run_handler(message.config.message_handler, message)
       Process.flag(:trap_exit, false)
       result
+    rescue
+      e ->
+        Logger.error "Error running message handler: #{inspect e}"
+        Logger.error inspect System.stacktrace
+        {:req, -1, true}
     catch
       :exit, b ->
         Logger.error "Caught exit running message handler: :exit, #{inspect b}"
@@ -198,11 +203,6 @@ defmodule NSQ.Message do
         {:req, -1, true}
       a, b ->
         Logger.error "Caught exception running message handler: #{inspect a}, #{inspect b}"
-        Logger.error inspect System.stacktrace
-        {:req, -1, true}
-    rescue
-      e ->
-        Logger.error "Error running message handler: #{inspect e}"
         Logger.error inspect System.stacktrace
         {:req, -1, true}
     end


### PR DESCRIPTION
This fixes two compiler warnings. `GenEvent` also gets flagged as deprecated which seems like a bigger change