### PR TITLE
Fix reversed instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,14 +193,14 @@ those commands if you want to run the tests.
 If you are using nsq < 1.0.0
 
 ```bash
-WORKER_ID=node-id foreman start
+WORKER_ID=worker-id foreman start
 mix test
 ```
 
 If you are using nsq >= 1.0.0
 
 ```bash
-WORKER_ID=worker-id foreman start
+WORKER_ID=node-id foreman start
 mix test
 ```
 


### PR DESCRIPTION
Encountered a strange error trying to run the test suite, and eventually figured out (from looking at `.travis.yml`) that these instructions in the README were the opposite of what they should be.