### PR TITLE
Test against Elixir 1.6 + pare down test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,15 @@
 language: elixir
 
 elixir:
-  - 1.4
-  - 1.5
+  - "1.4"
+  - "1.5"
+  - "1.6"
 
 otp_release:
-  - 19.3
-  - 20.0
+  - "19.3"
+  - "20.2"
 
 env:
-  - NSQ_DOWNLOAD=nsq-0.3.5.linux-amd64.go1.4.2 NSQ_VER=v0.3.5 WORKER_ID=worker-id
-  - NSQ_DOWNLOAD=nsq-0.3.6.linux-amd64.go1.5.1 NSQ_VER=v0.3.6 WORKER_ID=worker-id
-  - NSQ_DOWNLOAD=nsq-0.3.7.linux-amd64.go1.6 NSQ_VER=v0.3.7 WORKER_ID=worker-id
   - NSQ_DOWNLOAD=nsq-0.3.8.linux-amd64.go1.6.2 NSQ_VER=v0.3.8 WORKER_ID=worker-id
   - NSQ_DOWNLOAD=nsq-1.0.0-compat.linux-amd64.go1.8 NSQ_VER=v1.0.0-compat WORKER_ID=node-id
 


### PR DESCRIPTION
* Add Elixir 1.6 to the matrix

* Use string values for versions to avoid potential floating-point issues

* Remove older NSQ versions from the matrix to avoid combinatorial explosion

This last I'm not sure about, since I might be missing some context around why we currently test these versions. However, it seems reasonable: According to the NSQ release notes, 0.3.8 was released almost 2 years ago and is backwards-compatible with previous versions down to 0.3.5 (at least).