### PR TITLE
Clarify exception text when the channel name is invalid

### DIFF
--- a/lib/nsq/consumer.ex
+++ b/lib/nsq/consumer.ex
@@ -141,7 +141,7 @@ defmodule NSQ.Consumer do
     {:ok, config} = NSQ.Config.validate(config)
     {:ok, config} = NSQ.Config.normalize(config)
     unless is_valid_topic_name?(topic), do: raise "Invalid topic name #{topic}"
-    unless is_valid_channel_name?(channel), do: raise "Invalid channel name #{topic}"
+    unless is_valid_channel_name?(channel), do: raise "Invalid channel name #{channel}"
 
     state = %{@initial_state |
       topic: topic,


### PR DESCRIPTION
The current message is misleading since the topic may be valid and bear no similarity to the invalid channel name.