### PR TITLE
Allow GenServer options to be passed-in for producer

### DIFF
--- a/lib/nsq/producer.ex
+++ b/lib/nsq/producer.ex
@@ -143,13 +143,13 @@ defmodule NSQ.Producer do
   # ------------------------------------------------------- #
   # API Definitions                                         #
   # ------------------------------------------------------- #
-  @spec start_link(binary, NSQ.Config.t) :: {:ok, pid}
-  def start_link(topic, config) do
+  @spec start_link(binary, NSQ.Config.t, GenServer.options) :: {:ok, pid}
+  def start_link(topic, config, genserver_options \\ []) do
     {:ok, config} = NSQ.Config.validate(config || %NSQ.Config{})
     {:ok, config} = NSQ.Config.normalize(config)
     unless is_valid_topic_name?(topic), do: raise "Invalid topic name #{topic}"
     state = %{@initial_state | topic: topic, config: config}
-    GenServer.start_link(__MODULE__, state)
+    GenServer.start_link(__MODULE__, state, genserver_options)
   end
 
 


### PR DESCRIPTION
This allows using a producer directly in your supervisor tree such as:

```elixir
%{
  id: NSQ.Test.Producer,
  start: {
    NSQ.Producer.Supervisor,
    :start_link,
    [
      "test.json",
      %NSQ.Config{
        nsqds: ["127.0.0.1:4150"]
      },
      [name: :test_producer]
    ]
  }
}
```

Then using it via GenServer name lookup like: `NSQ.Producer.pub(:test_producer, "a message")`
this prevents needing to thread through a producer in the application and is an additive change with a default so it should be backwards compatible