### PR TITLE
Tdevries/fix all 1.8.warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,12 +119,20 @@ and perform actions based on that info.
 
 ```elixir
 defmodule EventForwarder do
-  use GenEvent
+    @behaviour :gen_event
 
-  def handle_event(event, parent) do
-    send parent, event
-    {:ok, parent}
-  end
+    def init(args) do
+      {:ok, args}
+    end
+
+    def handle_event(event, parent) do
+      send parent, event
+      {:ok, parent}
+    end
+
+    def handle_call(_event, _state) do
+      raise "not implemented"
+    end
 end
 
 def setup_consumer do

--- a/lib/nsq/connection/command.ex
+++ b/lib/nsq/connection/command.ex
@@ -41,7 +41,7 @@ defmodule NSQ.Connection.Command do
 
   @spec send_response_to_caller(C.state, binary) :: {:ok, C.state}
   def send_response_to_caller(state, data) do
-    GenEvent.notify(state.event_manager_pid, {:response, data})
+    :gen_event.notify(state.event_manager_pid, {:response, data})
     {item, cmd_resp_queue} = :queue.out(state.cmd_resp_queue)
     case item do
       {:value, {_cmd, {pid, ref}, :reply}} ->

--- a/lib/nsq/connection/message_handling.ex
+++ b/lib/nsq/connection/message_handling.ex
@@ -86,14 +86,14 @@ defmodule NSQ.Connection.MessageHandling do
 
   @spec respond_to_heartbeat(C.state) :: :ok
   defp respond_to_heartbeat(state) do
-    GenEvent.notify(state.event_manager_pid, :heartbeat)
+    :gen_event.notify(state.event_manager_pid, :heartbeat)
     state |> Buffer.send!(encode(:noop))
   end
 
 
   @spec log_error(C.state, binary, binary) :: any
   defp log_error(state, reason, data) do
-    GenEvent.notify(state.event_manager_pid, {:error, reason, data})
+    :gen_event.notify(state.event_manager_pid, {:error, reason, data})
     if reason do
       Logger.error "error: #{reason}\n#{inspect data}"
     else
@@ -115,7 +115,7 @@ defmodule NSQ.Connection.MessageHandling do
       msg_timeout: state.msg_timeout,
       event_manager_pid: state.event_manager_pid
     }
-    GenEvent.notify(state.event_manager_pid, {:message, message})
+    :gen_event.notify(state.event_manager_pid, {:message, message})
     GenServer.cast(state.parent, {:maybe_update_rdy, state.nsqd})
     NSQ.Message.Supervisor.start_child(state.msg_sup_pid, message)
     {:ok, state}

--- a/lib/nsq/consumer.ex
+++ b/lib/nsq/consumer.ex
@@ -169,7 +169,7 @@ defmodule NSQ.Consumer do
       if cons_state.config.event_manager do
         cons_state.config.event_manager
       else
-        {:ok, manager} = GenEvent.start_link
+        {:ok, manager} = :gen_event.start_link
         manager
       end
     cons_state = %{cons_state | event_manager_pid: manager}
@@ -344,7 +344,7 @@ defmodule NSQ.Consumer do
   @doc """
   If the event manager is not defined in NSQ.Config, it will be generated. So
   if you want to attach event handlers on the fly, you can use a syntax like
-  `NSQ.Consumer.event_manager(consumer) |> GenEvent.add_handler(MyHandler, [])`
+  `NSQ.Consumer.event_manager(consumer) |> :gen_event.add_handler(MyHandler, [])`
   """
   def event_manager(sup_pid) do
     cons = get(sup_pid)

--- a/lib/nsq/consumer/backoff.ex
+++ b/lib/nsq/consumer/backoff.ex
@@ -87,7 +87,7 @@ defmodule NSQ.Consumer.Backoff do
       {:ok, new_state} = RDY.update(cons, conn, 0, last_state)
       new_state
     end
-    GenEvent.notify(cons_state.event_manager_pid, backoff_signal)
+    :gen_event.notify(cons_state.event_manager_pid, backoff_signal)
     {:ok, _cons_state} = resume_later(cons, backoff_duration, cons_state)
   end
 
@@ -120,7 +120,7 @@ defmodule NSQ.Consumer.Backoff do
       {:ok, new_state} = RDY.update(cons, conn, count, last_state)
       new_state
     end
-    GenEvent.notify(cons_state.event_manager_pid, :resume)
+    :gen_event.notify(cons_state.event_manager_pid, :resume)
     {:ok, cons_state}
   end
 

--- a/lib/nsq/message.ex
+++ b/lib/nsq/message.ex
@@ -97,7 +97,7 @@ defmodule NSQ.Message do
   def fin(message) do
     Logger.debug("(#{inspect message.connection}) fin msg ID #{message.id}")
     message |> Buffer.send!(encode({:fin, message.id}))
-    GenEvent.notify(message.event_manager_pid, {:message_finished, message})
+    :gen_event.notify(message.event_manager_pid, {:message_finished, message})
     GenServer.call(message.consumer, {:start_stop_continue_backoff, :resume})
   end
 
@@ -137,7 +137,7 @@ defmodule NSQ.Message do
     end
 
     message |> Buffer.send!(encode({:req, message.id, delay}))
-    GenEvent.notify(message.event_manager_pid, {:message_requeued, message})
+    :gen_event.notify(message.event_manager_pid, {:message_requeued, message})
   end
 
 
@@ -244,7 +244,7 @@ defmodule NSQ.Message do
         # If we've waited this long, we can assume NSQD will requeue the
         # message on its own.
         Logger.warn "Msg #{message.id} timed out, quit processing it and expect nsqd to requeue"
-        GenEvent.notify(message.event_manager_pid, {:message_requeued, message})
+        :gen_event.notify(message.event_manager_pid, {:message_requeued, message})
         unlink_and_exit(message.parent)
         {:ok, :req}
     end

--- a/lib/nsq/producer.ex
+++ b/lib/nsq/producer.ex
@@ -97,7 +97,7 @@ defmodule NSQ.Producer do
       if pro_state.config.event_manager do
         pro_state.config.event_manager
       else
-        {:ok, manager} = GenEvent.start_link
+        {:ok, manager} = :gen_event.start_link
         manager
       end
     pro_state = %{pro_state | event_manager_pid: manager}

--- a/test/consumer_test.exs
+++ b/test/consumer_test.exs
@@ -1,10 +1,18 @@
 defmodule NSQ.ConsumerTest do
   defmodule EventForwarder do
-    use GenEvent
+    @behaviour :gen_event
+
+    def init(args) do
+      {:ok, args}
+    end
 
     def handle_event(event, parent) do
       send parent, event
       {:ok, parent}
+    end
+
+    def handle_call(_event, _state) do
+      raise "not implemented"
     end
   end
 
@@ -47,7 +55,7 @@ defmodule NSQ.ConsumerTest do
     })
 
     NSQ.Consumer.event_manager(consumer)
-      |> GenEvent.add_handler(NSQ.ConsumerTest.EventForwarder, self())
+      |> :gen_event.add_handler(NSQ.ConsumerTest.EventForwarder, self())
 
     HTTP.post("http://127.0.0.1:6751/pub?topic=#{@test_topic}", [body: "hello"])
     assert_receive {:message_finished, _}, 2000
@@ -73,7 +81,7 @@ defmodule NSQ.ConsumerTest do
     })
 
     NSQ.Consumer.event_manager(consumer)
-      |> GenEvent.add_handler(NSQ.ConsumerTest.EventForwarder, self())
+      |> :gen_event.add_handler(NSQ.ConsumerTest.EventForwarder, self())
 
     HTTP.post("http://127.0.0.1:6751/pub?topic=#{@test_topic}", [body: "hello"])
 
@@ -157,7 +165,7 @@ defmodule NSQ.ConsumerTest do
     })
 
     NSQ.Consumer.event_manager(consumer)
-      |> GenEvent.add_handler(NSQ.ConsumerTest.EventForwarder, self())
+      |> :gen_event.add_handler(NSQ.ConsumerTest.EventForwarder, self())
 
     HTTP.post("http://127.0.0.1:6751/pub?topic=#{@test_topic}", [body: "HTTP message"])
     assert_receive(:handled, 2000)
@@ -183,7 +191,7 @@ defmodule NSQ.ConsumerTest do
     })
 
     NSQ.Consumer.event_manager(consumer)
-      |> GenEvent.add_handler(NSQ.ConsumerTest.EventForwarder, self())
+      |> :gen_event.add_handler(NSQ.ConsumerTest.EventForwarder, self())
 
     [info] = NSQ.Consumer.conn_info(consumer) |> Map.values
     previous_timestamp = info.last_msg_timestamp
@@ -408,7 +416,7 @@ defmodule NSQ.ConsumerTest do
     })
 
     NSQ.Consumer.event_manager(sup_pid)
-      |> GenEvent.add_handler(NSQ.ConsumerTest.EventForwarder, self())
+      |> :gen_event.add_handler(NSQ.ConsumerTest.EventForwarder, self())
 
     consumer = Cons.get(sup_pid)
     cons_state = Cons.get_state(consumer)
@@ -612,7 +620,7 @@ defmodule NSQ.ConsumerTest do
     })
 
     NSQ.Consumer.event_manager(consumer)
-      |> GenEvent.add_handler(NSQ.ConsumerTest.EventForwarder, self())
+      |> :gen_event.add_handler(NSQ.ConsumerTest.EventForwarder, self())
 
     # Nothing is in flight, not starved
     assert NSQ.Consumer.starved?(consumer) == false

--- a/test/consumer_test.exs
+++ b/test/consumer_test.exs
@@ -357,7 +357,7 @@ defmodule NSQ.ConsumerTest do
 
   def assert_receive_n_times(msg, times, delay) do
     if times > 0 do
-      assert_receive(msg, delay)
+      assert_receive(^msg, delay)
       assert_receive_n_times(msg, times - 1, delay)
     end
   end

--- a/test/message_test.exs
+++ b/test/message_test.exs
@@ -9,7 +9,7 @@ defmodule NSQ.MessageTest do
   def build_raw_nsq_data(attrs \\ %{}) do
     timestamp = attrs[:timestamp] || now()
     attempts = attrs[:attempts] || 0
-    msg_id = attrs[:id] || String.ljust(SecureRandom.hex(8), 16, ?0)
+    msg_id = attrs[:id] || String.pad_trailing(SecureRandom.hex(8), 16, "0")
     data = attrs[:body] || "test data"
 
     <<timestamp :: size(64)>>


### PR DESCRIPTION
This PR fixes a bunch of warnings:

* Fixes warning unused variable `msg` in one of the tests.
* Fixes warnings related to using the GenEvent module.
* Fixes warning from using `ljust` instead of `pad_trailing`.
* Fixes warning where `HttpServer.start/1` wasn't defined.