### PR TITLE
Close the read/recv loop if we receive {:error, "socket closed"}

### DIFF
--- a/lib/nsq/connection/message_handling.ex
+++ b/lib/nsq/connection/message_handling.ex
@@ -12,6 +12,10 @@ defmodule NSQ.Connection.MessageHandling do
   """
   def recv_nsq_messages(conn_state, conn) do
     case conn_state |> Buffer.recv(4) do
+      # close the read loop if socket is closed
+      {:error, "socket closed"} ->
+        conn |> C.close(conn_state)
+
       {:error, :timeout} ->
         # If publishing is quiet, we won't receive any messages in the timeout.
         # This is fine. Let's just try again!

--- a/lib/nsq/connection/message_handling.ex
+++ b/lib/nsq/connection/message_handling.ex
@@ -14,6 +14,7 @@ defmodule NSQ.Connection.MessageHandling do
     case conn_state |> Buffer.recv(4) do
       # close the read loop if socket is closed
       {:error, "socket closed"} ->
+        NSQ.Logger.error("error: socket closed - closing read loop")
         conn |> C.close(conn_state)
 
       {:error, :timeout} ->


### PR DESCRIPTION
This PR adds handling for `{:error, "socket closed"}` similar to how the reference golang client handles these issues by closing the connection: https://github.com/nsqio/go-nsq/blob/master/conn.go#L50

Closing the connection in our case also terminates the process, which will cause the supervisor to spin up a new process.